### PR TITLE
Implement nested group updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ All light changes use a smooth 2-second transition for a more pleasant fade.
 The light controller now supports `rgb_color` and `rgbw_color` fields so you can
 set full RGB(W) colors from your lighting programs.
 
+Lighting programs can also operate on nested light groups using the
+`LightGroup` helpers. This allows updating an entire group or a specific
+entity within the hierarchy with a single call. The default program uses this
+mechanism to expand `light.tv_shelf_group` into individual shelf lights based on
+their enable switches.
+
 ### Preset scenes
 
 When the selected scene is `preset`, maestro only turns off the `light.living_temperature_lights` group and leaves other lights untouched. This allows the [scene_presets](https://github.com/Hypfer/hass-scene_presets) integration to run dynamic color scenes. Whenever a different scene is chosen, maestro sends a request to `scene_presets.stop_all_dynamic_scenes` to ensure any running dynamic scenes are stopped.

--- a/Sources/Lights/LightGroup.swift
+++ b/Sources/Lights/LightGroup.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// A recursive structure representing either a single light state or a group of lights.
+public indirect enum LightGroup {
+    case light(LightState)
+    case group([String: LightGroup])
+}
+
+public extension LightGroup {
+    /// Flattens the group into a list of `LightState` objects.
+    func flattened() -> [LightState] {
+        switch self {
+        case .light(let state):
+            return [state]
+        case .group(let children):
+            return children.values.flatMap { $0.flattened() }
+        }
+    }
+
+    /// Recursively updates the specified entity or group. Returns true if any entry was updated.
+    @discardableResult
+    mutating func update(entityId: String, with state: LightState) -> Bool {
+        switch self {
+        case .light:
+            return false
+        case .group(var children):
+            if var entry = children[entityId] {
+                entry.updateAllLeaves(with: state)
+                children[entityId] = entry
+                self = .group(children)
+                return true
+            }
+            var updated = false
+            for key in children.keys {
+                var entry = children[key]!
+                if entry.update(entityId: entityId, with: state) {
+                    children[key] = entry
+                    updated = true
+                    break
+                }
+            }
+            if updated { self = .group(children) }
+            return updated
+        }
+    }
+
+    /// Updates all leaf light states within this group to the provided state.
+    private mutating func updateAllLeaves(with state: LightState) {
+        switch self {
+        case .light:
+            self = .light(state)
+        case .group(var children):
+            for key in children.keys {
+                var entry = children[key]!
+                entry.updateAllLeaves(with: state)
+                children[key] = entry
+            }
+            self = .group(children)
+        }
+    }
+
+    /// Convenience wrapper to update multiple entity identifiers.
+    @discardableResult
+    mutating func update(entityIds: [String], with state: LightState) -> Bool {
+        var updated = false
+        for id in entityIds {
+            if update(entityId: id, with: state) { updated = true }
+        }
+        return updated
+    }
+}

--- a/Sources/Programs/LightProgramDefault.swift
+++ b/Sources/Programs/LightProgramDefault.swift
@@ -146,23 +146,34 @@ public struct LightProgramDefault: LightProgram {
                                     environment: StateContext.Environment,
                                     transition: Double) -> [LightState] {
         var expanded: [LightState] = []
+        let shelfIds = (1...5).map { "light.wled_tv_shelf_\($0)" }
         for state in changes {
             if state.entityId == "light.tv_shelf_group" {
-                for (idx, enabled) in environment.tvShelvesEnabled.enumerated() {
-                    let id = "light.wled_tv_shelf_\(idx + 1)"
+                var group = LightGroup.group(
+                    Dictionary(uniqueKeysWithValues: shelfIds.map { id in
+                        (id, LightGroup.light(LightState(entityId: id, on: false)))
+                    })
+                )
+                for (index, id) in shelfIds.enumerated() {
+                    let enabled = environment.tvShelvesEnabled[index]
+                    let shelfState: LightState
                     if enabled {
-                        expanded.append(LightState(entityId: id,
-                                                  on: state.on,
-                                                  brightness: state.brightness,
-                                                  colorTemperature: state.colorTemperature,
-                                                  effect: state.effect,
-                                                  transitionDuration: transition))
+                        shelfState = LightState(entityId: id,
+                                               on: state.on,
+                                               brightness: state.brightness,
+                                               colorTemperature: state.colorTemperature,
+                                               rgbColor: state.rgbColor,
+                                               rgbwColor: state.rgbwColor,
+                                               effect: state.effect,
+                                               transitionDuration: transition)
                     } else {
-                        expanded.append(LightState(entityId: id,
-                                                  on: false,
-                                                  transitionDuration: transition))
+                        shelfState = LightState(entityId: id,
+                                               on: false,
+                                               transitionDuration: transition)
                     }
+                    group.update(entityId: id, with: shelfState)
                 }
+                expanded.append(contentsOf: group.flattened())
             } else {
                 expanded.append(state)
             }

--- a/Tests/maestroTests/LightGroupTests.swift
+++ b/Tests/maestroTests/LightGroupTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import maestro
+
+final class LightGroupTests: XCTestCase {
+    func testFlattenedReturnsAllLeafStates() {
+        let group = LightGroup.group([
+            "light.a": .light(LightState(entityId: "light.a", on: true)),
+            "grp": .group([
+                "light.b": .light(LightState(entityId: "light.b", on: false)),
+                "light.c": .light(LightState(entityId: "light.c", on: true))
+            ])
+        ])
+        let ids = Set(group.flattened().map { $0.entityId })
+        XCTAssertEqual(ids, ["light.a", "light.b", "light.c"])
+    }
+
+    func testUpdateLeafEntity() {
+        var group = LightGroup.group([
+            "light.a": .light(LightState(entityId: "light.a", on: false))
+        ])
+        group.update(entityId: "light.a", with: LightState(entityId: "light.a", on: true))
+        let state = group.flattened().first { $0.entityId == "light.a" }
+        XCTAssertEqual(state?.on, true)
+    }
+
+    func testUpdateGroupUpdatesAllChildren() {
+        var group = LightGroup.group([
+            "parent": .group([
+                "child1": .light(LightState(entityId: "child1", on: false)),
+                "child2": .light(LightState(entityId: "child2", on: false))
+            ])
+        ])
+        let newState = LightState(entityId: "child1", on: true, brightness: 10)
+        group.update(entityId: "parent", with: newState)
+        let states = group.flattened()
+        for st in states {
+            XCTAssertEqual(st.on, true)
+            XCTAssertEqual(st.brightness, 10)
+        }
+    }
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -83,7 +83,7 @@ Feature 4 of the roadmap calls for more refined time-of-day logic within the Swi
   whatever dynamic effect was previously active. The comparison should ignore
   case so `"Solid"` and `"solid"` are treated the same.
 
-### 7. Nested Group Updates
+### 7. Nested Group Updates *(implemented)*
 - Implement recursive group handling similar to `process_light_group`
 - Add support for `update_specific_light` functionality
 - Create helper functions for group operations


### PR DESCRIPTION
## Summary
- introduce `LightGroup` to represent nested light structures
- support recursive group updates and flattening
- document nested light group support in README
- mark roadmap item 7 as implemented
- test new group helper functionality
- expand TV shelf group using `LightGroup`

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_684ba2e23d748326a99b8ba4dbe2b038