### PR TITLE
Fix base image tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,6 @@ When the selected scene is `preset`, maestro only turns off the `light.living_te
 
 For details on running maestro as a Home Assistant add-on, see [docs/addon.md](docs/addon.md).
 The add-on's Dockerfile installs Swift using the version in `.swift-version` and
-uses `ghcr.io/home-assistant/amd64-addon-base:latest` for both build and runtime.
+uses `ghcr.io/home-assistant/amd64-addon-base:14` for both build and runtime.
 See [docs/devcontainer.md](docs/devcontainer.md) for more information.
 

--- a/docs/addon.md
+++ b/docs/addon.md
@@ -23,7 +23,7 @@ Home Assistant expects this structure when cloning the repository as an add-on s
 
 The Dockerfile should:
 
-1. Use the Home Assistant add-on base image (`ghcr.io/home-assistant/amd64-addon-base:latest`) as both the build and runtime stage.
+1. Use the Home Assistant add-on base image (`ghcr.io/home-assistant/amd64-addon-base:14`) as both the build and runtime stage.
 2. Copy `.swift-version` and install the matching Swift release:
    ```Dockerfile
    COPY .swift-version /tmp/.swift-version
@@ -70,7 +70,7 @@ description: Home Assistant lights orchestrator
 startup: application
 boot: auto
 build_from:
-  amd64: ghcr.io/home-assistant/amd64-addon-base:latest
+  amd64: ghcr.io/home-assistant/amd64-addon-base:14
 options:
   baseurl: http://homeassistant.local:8123/
   token: ''

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,21 +1,21 @@
 # Add-on build container
 
 The add-on uses the official Home Assistant base image
-`ghcr.io/home-assistant/amd64-addon-base:latest` for both building and running.
+`ghcr.io/home-assistant/amd64-addon-base:14` for both building and running.
 This keeps the environment identical to what Home Assistant expects.
 
 The `docker/Dockerfile` installs the Swift compiler specified in `.swift-version`
 and then builds the project:
 
 ```Dockerfile
-FROM ghcr.io/home-assistant/amd64-addon-base:latest AS build
+FROM ghcr.io/home-assistant/amd64-addon-base:14 AS build
 COPY .swift-version /tmp/.swift-version
 RUN SWIFT_VERSION=$(cat /tmp/.swift-version) && \
     curl -sL https://swift.org/builds/swift-${SWIFT_VERSION}-release/ubuntu2004/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04.tar.gz \
       | tar xz -C /usr/ && \
     ln -s /usr/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04/usr/bin/swift /usr/bin/swift
 # ... build maestro ...
-FROM ghcr.io/home-assistant/amd64-addon-base:latest
+FROM ghcr.io/home-assistant/amd64-addon-base:14
 ```
 
 When Home Assistant builds the add-on it pulls these images automatically. Local

--- a/maestro/Dockerfile
+++ b/maestro/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM ghcr.io/home-assistant/amd64-addon-base:latest AS build
+FROM ghcr.io/home-assistant/amd64-addon-base:14 AS build
 WORKDIR /build
 COPY .swift-version /tmp/.swift-version
 RUN SWIFT_VERSION=$(cat /tmp/.swift-version) && \
@@ -10,7 +10,7 @@ COPY .. .
 RUN swift build -c release
 
 # Runtime stage
-FROM ghcr.io/home-assistant/amd64-addon-base:latest
+FROM ghcr.io/home-assistant/amd64-addon-base:14
 WORKDIR /app
 COPY --from=build /build/.build/release/maestro /usr/local/bin/maestro
 COPY run.sh /usr/local/bin/run.sh

--- a/maestro/config.yaml
+++ b/maestro/config.yaml
@@ -5,7 +5,7 @@ description: Home Assistant lights orchestrator
 startup: application
 boot: auto
 build_from:
-  amd64: ghcr.io/home-assistant/amd64-addon-base:latest
+  amd64: ghcr.io/home-assistant/amd64-addon-base:14
 options:
   baseurl: http://homeassistant.local:8123/
   token: ''


### PR DESCRIPTION
## Summary
- fix base image not found by using `ghcr.io/home-assistant/amd64-addon-base:14`
- update add-on docs and README

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684cba35faa483268cdb96c929a78004