### PR TITLE
Switch to new build images

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ their enable switches.
 When the selected scene is `preset`, maestro only turns off the `light.living_temperature_lights` group and leaves other lights untouched. This allows the [scene_presets](https://github.com/Hypfer/hass-scene_presets) integration to run dynamic color scenes. Whenever a different scene is chosen, maestro sends a request to `scene_presets.stop_all_dynamic_scenes` to ensure any running dynamic scenes are stopped.
 
 For details on running maestro as a Home Assistant add-on, see [docs/addon.md](docs/addon.md).
-The add-on's Dockerfile installs Swift using the version in `.swift-version` and
-uses `ghcr.io/home-assistant/amd64-addon-base:14` for both build and runtime.
+The add-on's Dockerfile builds the binary using `swift:6.1-focal` and
+uses `ghcr.io/home-assistant/amd64-addon-base:latest` for the runtime image.
 See [docs/devcontainer.md](docs/devcontainer.md) for more information.
 

--- a/docs/addon.md
+++ b/docs/addon.md
@@ -23,18 +23,10 @@ Home Assistant expects this structure when cloning the repository as an add-on s
 
 The Dockerfile should:
 
-1. Use the Home Assistant add-on base image (`ghcr.io/home-assistant/amd64-addon-base:14`) as both the build and runtime stage.
-2. Copy `.swift-version` and install the matching Swift release:
-   ```Dockerfile
-   COPY .swift-version /tmp/.swift-version
-   RUN SWIFT_VERSION=$(cat /tmp/.swift-version) && \
-       curl -sL https://swift.org/builds/swift-${SWIFT_VERSION}-release/ubuntu2004/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04.tar.gz \
-         | tar xz -C /usr/ && \
-       ln -s /usr/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04/usr/bin/swift /usr/bin/swift
-   ```
-3. Copy the repository into the container and run `swift build -c release` to produce the `maestro` binary.
-4. Copy the compiled `maestro` binary and the `run.sh` script into the runtime image.
-5. Set `run.sh` as the container entrypoint.
+1. Use `swift:6.1-focal` to compile the project and `ghcr.io/home-assistant/amd64-addon-base:latest` as the runtime image.
+2. Copy the repository into the container and run `swift build -c release` to produce the `maestro` binary.
+3. Copy the compiled `maestro` binary and the `run.sh` script into the runtime image.
+4. Set `run.sh` as the container entrypoint.
 
 This multi-stage build keeps the final image small while compiling the Swift code during the build step.
 
@@ -70,7 +62,7 @@ description: Home Assistant lights orchestrator
 startup: application
 boot: auto
 build_from:
-  amd64: ghcr.io/home-assistant/amd64-addon-base:14
+  amd64: ghcr.io/home-assistant/amd64-addon-base:latest
 options:
   baseurl: http://homeassistant.local:8123/
   token: ''

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,21 +1,11 @@
 # Add-on build container
 
-The add-on uses the official Home Assistant base image
-`ghcr.io/home-assistant/amd64-addon-base:14` for both building and running.
-This keeps the environment identical to what Home Assistant expects.
-
-The `docker/Dockerfile` installs the Swift compiler specified in `.swift-version`
-and then builds the project:
+The add-on compiles using the official Swift image and then runs on the Home Assistant base image.
 
 ```Dockerfile
-FROM ghcr.io/home-assistant/amd64-addon-base:14 AS build
-COPY .swift-version /tmp/.swift-version
-RUN SWIFT_VERSION=$(cat /tmp/.swift-version) && \
-    curl -sL https://swift.org/builds/swift-${SWIFT_VERSION}-release/ubuntu2004/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04.tar.gz \
-      | tar xz -C /usr/ && \
-    ln -s /usr/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04/usr/bin/swift /usr/bin/swift
+FROM swift:6.1-focal AS build
 # ... build maestro ...
-FROM ghcr.io/home-assistant/amd64-addon-base:14
+FROM ghcr.io/home-assistant/amd64-addon-base:latest
 ```
 
 When Home Assistant builds the add-on it pulls these images automatically. Local

--- a/maestro/Dockerfile
+++ b/maestro/Dockerfile
@@ -1,16 +1,11 @@
 # Build stage
-FROM ghcr.io/home-assistant/amd64-addon-base:14 AS build
+FROM swift:6.1-focal AS build
 WORKDIR /build
-COPY .swift-version /tmp/.swift-version
-RUN SWIFT_VERSION=$(cat /tmp/.swift-version) && \
-    curl -sL https://swift.org/builds/swift-${SWIFT_VERSION}-release/ubuntu2004/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04.tar.gz \
-      | tar xz -C /usr/ && \
-    ln -s /usr/swift-${SWIFT_VERSION}-RELEASE-ubuntu20.04/usr/bin/swift /usr/bin/swift
 COPY .. .
 RUN swift build -c release
 
 # Runtime stage
-FROM ghcr.io/home-assistant/amd64-addon-base:14
+FROM ghcr.io/home-assistant/amd64-addon-base:latest
 WORKDIR /app
 COPY --from=build /build/.build/release/maestro /usr/local/bin/maestro
 COPY run.sh /usr/local/bin/run.sh

--- a/maestro/config.yaml
+++ b/maestro/config.yaml
@@ -5,7 +5,7 @@ description: Home Assistant lights orchestrator
 startup: application
 boot: auto
 build_from:
-  amd64: ghcr.io/home-assistant/amd64-addon-base:14
+  amd64: ghcr.io/home-assistant/amd64-addon-base:latest
 options:
   baseurl: http://homeassistant.local:8123/
   token: ''


### PR DESCRIPTION
## Summary
- use `swift:6.1-focal` for compiling
- run on `ghcr.io/home-assistant/amd64-addon-base:latest`
- document the new images

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684cc09afd008326b663fafec36d06b6