### PR TITLE
Use prebuilt image in Dockerfile

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "6.1"
+
+      - name: Run tests
+        run: swift test
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
@@ -46,7 +54,7 @@ jobs:
           file: ./maestro/Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
-            BUILD_FROM=ghcr.io/hassio-addons/base/amd64:13.2.0
+            MAESTRO_IMAGE=ghcr.io/${{ github.repository_owner }}/maestro:${{ github.ref_name }}
             BUILD_ARCH=amd64
             BUILD_VERSION=${{ github.ref_name }}
           push: true

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ their enable switches.
 When the selected scene is `preset`, maestro only turns off the `light.living_temperature_lights` group and leaves other lights untouched. This allows the [scene_presets](https://github.com/Hypfer/hass-scene_presets) integration to run dynamic color scenes. Whenever a different scene is chosen, maestro sends a request to `scene_presets.stop_all_dynamic_scenes` to ensure any running dynamic scenes are stopped.
 
 For details on running maestro as a Home Assistant add-on, see [docs/addon.md](docs/addon.md).
-The add-on's Dockerfile builds the binary using `swift:6.1-focal` and
-uses `ghcr.io/home-assistant/amd64-addon-base:latest` for the runtime image.
-See [docs/devcontainer.md](docs/devcontainer.md) for more information.
+The add-on's Dockerfile now pulls the prebuilt image from GitHub Container Registry
+and simply copies the `run.sh` script. See [docs/devcontainer.md](docs/devcontainer.md)
+for more information.
 

--- a/docs/addon.md
+++ b/docs/addon.md
@@ -21,14 +21,13 @@ Home Assistant expects this structure when cloning the repository as an add-on s
 
 ## 2. Dockerfile
 
-The Dockerfile should:
+The Dockerfile now pulls the prebuilt `maestro` image from GitHub Container Registry:
 
-1. Use `swift:6.1-focal` to compile the project and `ghcr.io/home-assistant/amd64-addon-base:latest` as the runtime image.
-2. Copy the repository into the container and run `swift build -c release` to produce the `maestro` binary.
-3. Copy the compiled `maestro` binary and the `run.sh` script into the runtime image.
-4. Set `run.sh` as the container entrypoint.
+```Dockerfile
+FROM ghcr.io/<owner>/maestro:latest
+```
 
-This multi-stage build keeps the final image small while compiling the Swift code during the build step.
+It only copies `run.sh` into the container and sets it as the entrypoint. The heavy Swift compilation happens in CI when publishing the `maestro` image.
 
 ## 3. Entrypoint script
 
@@ -61,8 +60,6 @@ slug: maestro
 description: Home Assistant lights orchestrator
 startup: application
 boot: auto
-build_from:
-  amd64: ghcr.io/home-assistant/amd64-addon-base:latest
 options:
   baseurl: http://homeassistant.local:8123/
   token: ''
@@ -75,7 +72,7 @@ schema:
   simulate: bool
   no_notify: bool
   program: str?
-image: local/maestro
+image: ghcr.io/<owner>/maestro
 ```
 
 Users can adjust the options in the Home Assistant UI. They are exported as environment variables with the same names in uppercase.

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,14 +1,12 @@
 # Add-on build container
 
-The add-on compiles using the official Swift image and then runs on the Home Assistant base image.
+The add-on now reuses the maestro image published to GitHub Container Registry.
 
 ```Dockerfile
-FROM swift:6.1-focal AS build
-# ... build maestro ...
-FROM ghcr.io/home-assistant/amd64-addon-base:latest
+FROM ghcr.io/<owner>/maestro:latest
 ```
 
-When Home Assistant builds the add-on it pulls these images automatically. Local
+When Home Assistant builds the add-on it pulls this image automatically. Local
 builds behave the same way:
 
 ```bash

--- a/maestro/Dockerfile
+++ b/maestro/Dockerfile
@@ -1,19 +1,9 @@
-ARG BUILD_FROM
-FROM ${BUILD_FROM}
+ARG MAESTRO_IMAGE
+ARG BUILD_ARCH
+ARG BUILD_VERSION
+FROM ${MAESTRO_IMAGE}
 
-# Build stage
-FROM swift:5.9-jammy AS swift-build
-WORKDIR /build
-COPY Package.swift ./
-COPY Sources ./Sources
-COPY Tests ./Tests
-RUN swift package resolve
-RUN swift build -c release
-
-# Runtime stage
-FROM ${BUILD_FROM}
 WORKDIR /app
-COPY --from=swift-build /build/.build/release/maestro /usr/local/bin/maestro
 COPY run.sh /usr/local/bin/run.sh
 RUN chmod +x /usr/local/bin/run.sh
 

--- a/maestro/config.yaml
+++ b/maestro/config.yaml
@@ -4,8 +4,6 @@ slug: maestro
 description: Home Assistant lights orchestrator
 startup: application
 boot: auto
-build_from:
-  amd64: ghcr.io/home-assistant/amd64-addon-base:latest
 options:
   baseurl: http://homeassistant.local:8123/
   token: ''
@@ -18,7 +16,7 @@ schema:
   simulate: bool
   no_notify: bool
   program: str?
-image: local/maestro
+image: ghcr.io/<owner>/maestro
 arch:
   - amd64
   - armhf


### PR DESCRIPTION
## Summary
- use prebuilt maestro image from GHCR in Dockerfile
- update README and docs for new Docker approach
- adjust add-on config to reference GHCR image
- update CI build arguments

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684d97b1f9e88326aac11a70ad4ddb9c