### PR TITLE
Fix Dockerfile build args

### DIFF
--- a/maestro/Dockerfile
+++ b/maestro/Dockerfile
@@ -3,6 +3,9 @@ ARG BUILD_ARCH
 ARG BUILD_VERSION
 FROM ${BUILD_FROM}
 
+# Re-declare build arguments for use after the FROM directive.
+ARG BUILD_ARCH
+ARG BUILD_VERSION
 ARG TEMPIO_VERSION
 RUN \
     curl -sSLf -o /usr/bin/tempio \


### PR DESCRIPTION
## Summary
- fix Dockerfile so BUILD_ARCH and BUILD_VERSION are available after `FROM`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684dcf77768083269c1716c6c12fab20