### PR TITLE
Fix default build image for Dockerfile

### DIFF
--- a/docs/addon.md
+++ b/docs/addon.md
@@ -29,6 +29,8 @@ FROM $BUILD_FROM
 ```
 
 `home-assistant/builder` supplies the `BUILD_FROM` argument when building for each architecture.
+For local builds, the Dockerfile defaults to the amd64 base image. Override it
+with `--build-arg BUILD_FROM=<image>` if needed.
 
 ## 3. Entrypoint script
 

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -9,3 +9,6 @@ Local builds mirror the Home Assistant process:
 docker build -t maestro-addon ./docker
 docker run --rm maestro-addon
 ```
+The Dockerfile defaults to the amd64 base image, so you can build locally
+without specifying `BUILD_FROM`. Pass `--build-arg BUILD_FROM=<image>` to use a
+different base.

--- a/maestro/Dockerfile
+++ b/maestro/Dockerfile
@@ -1,4 +1,6 @@
-ARG BUILD_FROM
+# Base image for local builds. Home Assistant's builder overrides this
+# when building for each architecture using `build.yaml`.
+ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.15
 ARG BUILD_ARCH
 ARG BUILD_VERSION
 FROM ${BUILD_FROM}


### PR DESCRIPTION
## Summary
- fix Dockerfile by providing a default base image
- document how to override `BUILD_FROM` for local builds

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684dd0acaa4c8326bc0004c63933a815