### PR TITLE
Remove test step from docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,8 +21,6 @@ jobs:
           swift-version: "6.1"
           experimental: true
 
-      - name: Run tests
-        run: swift test
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
## Summary
- remove the `Run tests` step from the publish workflow

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684dd276c97c8326b2ec2b28b9e95843