### PR TITLE
Add configurable server port

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Copy Maestro binary into add-on
         run: |
-          mkdir -p maestro/rootfs/bin
-          cp .build/release/maestro maestro/rootfs/bin/
+          mkdir -p maestro/rootfs/usr/local/bin
+          cp .build/release/maestro maestro/rootfs/usr/local/bin/
 
       - name: Get version from config
         id: get_version

--- a/.github/workflows/debug-image.yml
+++ b/.github/workflows/debug-image.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Copy Maestro binary into add-on
         run: |
-          mkdir -p maestro/rootfs/bin
-          cp .build/release/maestro maestro/rootfs/bin/
+          mkdir -p maestro/rootfs/usr/local/bin
+          cp .build/release/maestro maestro/rootfs/usr/local/bin/
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ swift run maestro
  --simulate # print light commands to stdout instead of sending them
  --no-notify # disable Home Assistant persistent notifications on failures
  --program secondary # choose the light program to run (`default` or `secondary`)
+ --port 8080 # port for the HTTP server (default 8080)
 ```
 
 The package builds on Linux and macOS. On macOS the POSIX server code uses the
@@ -41,6 +42,7 @@ Example request:
 ```bash
 curl http://localhost:8080/run
 ```
+Replace `8080` with the port specified by `--port` if different.
 
 If the path is anything other than `/run`, the server responds with `404 Not
 Found`.

--- a/Sources/Core/ArgumentParser.swift
+++ b/Sources/Core/ArgumentParser.swift
@@ -6,6 +6,7 @@ struct MaestroOptions {
     var simulate: Bool = false
     var programName: String = "default"
     var notificationsEnabled: Bool = true
+    var port: Int32 = 8080
 }
 
 func parseArguments(_ args: [String]) -> MaestroOptions {
@@ -33,6 +34,12 @@ func parseArguments(_ args: [String]) -> MaestroOptions {
             options.programName = args[idx]
         } else if arg == "--no-notify" || arg == "--disable-notifications" {
             options.notificationsEnabled = false
+        } else if arg.hasPrefix("--port=") {
+            let value = String(arg.dropFirst("--port=".count))
+            if let p = Int32(value) { options.port = p }
+        } else if arg == "--port", idx + 1 < args.count {
+            idx += 1
+            if let p = Int32(args[idx]) { options.port = p }
         }
         idx += 1
     }

--- a/Sources/Core/main.swift
+++ b/Sources/Core/main.swift
@@ -19,4 +19,4 @@ default:
     program = LightProgramDefault()
 }
 let maestro = Maestro(states: states, lights: lights, program: program, logger: logger)
-try startServer(on: 8080, maestro: maestro)
+try startServer(on: options.port, maestro: maestro)

--- a/Tests/maestroTests/ArgumentParserTests.swift
+++ b/Tests/maestroTests/ArgumentParserTests.swift
@@ -8,7 +8,18 @@ final class ArgumentParserTests: XCTestCase {
     }
 
     func testNotificationsEnabledByDefault() {
-        let opts = parseArguments(["maestro"]) 
+        let opts = parseArguments(["maestro"])
         XCTAssertTrue(opts.notificationsEnabled)
+        XCTAssertEqual(opts.port, 8080)
+    }
+
+    func testPortFlagWithEquals() {
+        let opts = parseArguments(["maestro", "--port=9000"])
+        XCTAssertEqual(opts.port, 9000)
+    }
+
+    func testPortFlagWithSpace() {
+        let opts = parseArguments(["maestro", "--port", "1234"])
+        XCTAssertEqual(opts.port, 1234)
     }
 }


### PR DESCRIPTION
## Summary
- support `--port` CLI option
- document the `--port` option in README
- test new argument handling
- place compiled binary into `/usr/local/bin` during image build

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_684df3f846d883269a03fb5e3c2df56f