### PR TITLE
Fix run.sh exec fallback

### DIFF
--- a/docs/addon.md
+++ b/docs/addon.md
@@ -45,7 +45,11 @@ ARGS=()
 [ "$NO_NOTIFY" = "true" ] && ARGS+=(--no-notify)
 [ -n "$PROGRAM" ] && ARGS+=(--program "$PROGRAM")
 
-exec /usr/local/bin/maestro "${ARGS[@]}"
+if [[ -x /usr/local/bin/maestro ]]; then
+  exec /usr/local/bin/maestro "${ARGS[@]}"
+else
+  exec swift run maestro "${ARGS[@]}"
+fi
 ```
 
 The environment variables (`BASEURL`, `TOKEN`, etc.) are injected by Home Assistant based on user configuration options.

--- a/maestro/run.sh
+++ b/maestro/run.sh
@@ -8,4 +8,8 @@ ARGS=()
 [ "$NO_NOTIFY" = "true" ] && ARGS+=(--no-notify)
 [ -n "$PROGRAM" ] && ARGS+=(--program "$PROGRAM")
 
-exec /usr/local/bin/maestro "${ARGS[@]}"
+if [[ -x /usr/local/bin/maestro ]]; then
+  exec /usr/local/bin/maestro "${ARGS[@]}"
+else
+  exec swift run maestro "${ARGS[@]}"
+fi


### PR DESCRIPTION
## Summary
- add a fallback to `swift run maestro` when `/usr/local/bin/maestro` is missing
- document the updated script in addon docs

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684df6efd4788326b6ec6dbea12bf14f